### PR TITLE
Downgraded material library to prevent startup crash

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
     implementation ("androidx.core:core-ktx:1.12.0")
     implementation ("androidx.core:core-splashscreen:1.0.1")
     implementation ("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
-    implementation ("com.google.android.material:material:1.11.0")
+    implementation ("com.google.android.material:material:1.10.0")
     implementation (kotlin("stdlib", version = kotlinVersion))
     implementation ("com.github.cachapa:ExpandableLayout:2.9.2")
 }


### PR DESCRIPTION
#### What is it?
- Bugfix (user facing)

#### Description of the changes in your PR
- Downgraded material library to 1.10 from 1.11 to prevent startup crash on Android 13.

#### Fixes the following issue(s)
Lunar launcher crashes if launched on Android 13 (and probably lower).

I have tested the launcher with this change on the following and the crash no longer occurs on the older Android versions:
- Fairphone 4 with DivestOS January 2024 update (Android 13).
- Android studio virtual API 34 Pixel 3a (Android 14).
- Android studio virtual API 33 Pixel 3a (Android 13).
- Android studio virtual API 31 Pixel 3a (Android 12).