### PR TITLE
Introduces the ability to rename apps. Additionally it fixes Issue#117

### DIFF
--- a/app/src/main/kotlin/rasel/lunar/launcher/apps/AppMenu.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/apps/AppMenu.kt
@@ -93,7 +93,8 @@ internal class AppMenu : BottomSheetDialogFragment() {
         }
 
         /* get default app name */
-        defAppName = packageManager.getApplicationLabel(appInfo).toString()
+        val resolve = packageManager.resolveActivity(Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER).setPackage(packageName), 0)
+        defAppName = resolve?.loadLabel(packageManager).toString()
 
         /* set application name and package name */
         binding.appName.setText(appNamesPrefs?.getString(packageName, defAppName))

--- a/app/src/main/kotlin/rasel/lunar/launcher/apps/AppsAdapter.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/apps/AppsAdapter.kt
@@ -26,6 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.updatePadding
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -103,7 +104,10 @@ internal class AppsAdapter(
 
             /* on long click - open app menu */
             setOnLongClickListener {
-                AppMenu().show(fragmentManager, item.packageName)
+                AppMenu().let {
+                    it.setStyle(DialogFragment.STYLE_NORMAL, R.style.BottomSheetDialog)
+                    it.show(fragmentManager, item.packageName)
+                }
                 true
             }
         }

--- a/app/src/main/kotlin/rasel/lunar/launcher/helpers/Constants.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/helpers/Constants.kt
@@ -81,6 +81,9 @@ internal class Constants {
         const val requestPickWidget = 103
         const val requestCreateWidget = 104
 
+        /* app names */
+        const val PREFS_APP_NAMES = "rasel.lunar.launcher.APP_NAMES"
+
         /* favorite apps */
         const val PREFS_FAVORITE_APPS = "rasel.lunar.launcher.FAVORITE_APPS"
         const val KEY_APP_NO_ = "app_no_"

--- a/app/src/main/res/layout/app_menu.xml
+++ b/app/src/main/res/layout/app_menu.xml
@@ -4,16 +4,32 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
-    android:padding="@dimen/twelve">
+    android:padding="@dimen/twelve"
+    android:clickable="true"
+    android:focusableInTouchMode="true">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/appName"
-        style="@style/TextAppearance.Material3.TitleLarge"
-        android:layout_width="wrap_content"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/appNameInputLayout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center"
+        app:hintEnabled="false"
+        app:boxStrokeWidth="@dimen/zero"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent" >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/appName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="@dimen/zero"
+            android:gravity="center"
+            android:padding="@dimen/eight"
+            android:inputType="textNoSuggestions"
+            android:textAppearance="@style/TextAppearance.Material3.TitleLarge" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/appPackage"
@@ -23,7 +39,7 @@
         android:layout_marginTop="@dimen/eight"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/appName" />
+        app:layout_constraintTop_toBottomOf="@+id/appNameInputLayout" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/activityBrowser"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -15,6 +15,7 @@
 
     <style name="BottomSheetDialog" parent="Theme.Material3.DayNight.BottomSheetDialog">
         <item name="android:windowSoftInputMode">adjustResize</item>
+        <item name="android:navigationBarColor">?attr/colorSurface</item>
     </style>
 
     <style name="SettingsNavBar">


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [x] Feature request (user facing)
- [ ] Codebase improvement (dev facing)

#### Description of the changes in your PR
The main change is the implementation of the ability to rename apps.
The changed name is stored in a shared preference file named `rasel.lunar.launcher.APP_NAMES`.
`.../values/styles.xml` change also have an effect on To-Do add new/update dialog. But it remains unchanged for consistency.

#### Flaws
- `AppDrawer.fetchApps()` has been made public.
Originally it had no way to update the app drawer automatically(to show the changes). The changes would only appear when the app drawer is updated manually. As a temporary measure(?), it calls `AppDrawer.fetchApps()` which has been **made public**.

#### Fixes the following issue(s)
- #117 

#### Screen Capture

https://github.com/iamrasel/lunar-launcher/assets/125657944/59de5cca-abf8-4b01-80c9-0e9c864bf429