### PR TITLE
Change appName inputType to 'textNoSuggestions'

### DIFF
--- a/app/src/main/res/layout/app_menu.xml
+++ b/app/src/main/res/layout/app_menu.xml
@@ -26,6 +26,7 @@
             android:minWidth="@dimen/zero"
             android:gravity="center"
             android:padding="@dimen/eight"
+            android:inputType="textNoSuggestions"
             android:textAppearance="@style/TextAppearance.Material3.TitleLarge" />
     </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature request (user facing)
- [ ] Codebase improvement (dev facing)

#### Description of the changes in your PR
- Changed inputType of appName back to 'textNoSuggestions'
- 'text" is used so we can capture KEYCODE_ENTER instead of it adding a newline, also without it there can be seen some unusual cursor behavior.
- 'noSuggestions' is used to get rid of red spell checking mark(Keyboard suggestions still works).

#### Fixes the following issue(s)
- Unusual cursor behavior when appName is focused-

https://github.com/iamrasel/lunar-launcher/assets/125657944/8ff2bede-3f60-444d-ab32-8ee83b8ffb7b


- Consisting red spell checking mark when appName is out of focus
- Enter key adds new line
