### PR TITLE
Fix issue #129

### DIFF
--- a/app/src/main/kotlin/rasel/lunar/launcher/LauncherActivity.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/LauncherActivity.kt
@@ -63,8 +63,8 @@ import rasel.lunar.launcher.home.LauncherHome
 internal class LauncherActivity : AppCompatActivity() {
 
     private lateinit var binding: LauncherActivityBinding
-    private lateinit var viewPager: ViewPager2
     private lateinit var settingsPrefs: SharedPreferences
+    lateinit var viewPager: ViewPager2
 
     companion object {
         @JvmStatic var lActivity: LauncherActivity? = null

--- a/app/src/main/kotlin/rasel/lunar/launcher/todos/TodoManager.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/todos/TodoManager.kt
@@ -57,6 +57,12 @@ internal class TodoManager : Fragment() {
     override fun onResume() {
         super.onResume()
         refreshList()
+        lActivity!!.viewPager.isUserInputEnabled = false
+    }
+
+    override fun onPause() {
+        super.onPause()
+        lActivity!!.viewPager.isUserInputEnabled = true
     }
 
     fun refreshList() {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature request (user facing)
- [ ] Codebase improvement (dev facing)

#### Description of the changes in your PR
- Toggle viewPager.isUserInputEnabled when ToDoManager is focused and unfocused, so that the user can't swipe to another window

#### Flaws
- Does expose a private variable(viewPager in LauncherActivity.kt) to public

#### Fixes the following issue(s)
- #129