### PR TITLE
Fix issue #122

### DIFF
--- a/app/src/main/kotlin/rasel/lunar/launcher/LauncherActivity.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/LauncherActivity.kt
@@ -204,7 +204,8 @@ internal class LauncherActivity : AppCompatActivity() {
 
                 view.updatePadding(0, topInset, 0, it.bottom)
             }
-            WindowInsetsCompat.CONSUMED
+            // return the insets to get it in AppDrawer>handleWindowInsets()
+            windowInsets
         }
     }
 

--- a/app/src/main/kotlin/rasel/lunar/launcher/apps/AppDrawer.kt
+++ b/app/src/main/kotlin/rasel/lunar/launcher/apps/AppDrawer.kt
@@ -24,6 +24,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
@@ -34,7 +35,10 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.GridLayoutManager
@@ -57,7 +61,6 @@ import rasel.lunar.launcher.helpers.Constants.Companion.KEY_STATUS_BAR
 import rasel.lunar.launcher.helpers.Constants.Companion.PREFS_APP_NAMES
 import rasel.lunar.launcher.helpers.Constants.Companion.PREFS_SETTINGS
 import java.text.Normalizer
-import java.util.*
 import java.util.regex.Pattern
 
 
@@ -125,6 +128,7 @@ internal class AppDrawer : Fragment() {
         setLayout()
         fetchApps()
         getAlphabetItems()
+        handleWindowInsets()
         setKeyboardPadding()
 
         return binding.root
@@ -239,6 +243,25 @@ internal class AppDrawer : Fragment() {
                 }
                 binding.alphabets.invalidate()
             }
+        }
+    }
+
+    @SuppressLint("RtlHardcoded")
+    private fun handleWindowInsets() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars()).let {
+                    val leftInsets =
+                        if (settingsPrefs!!.getInt(KEY_DRAW_ALIGN, Gravity.CENTER) == Gravity.LEFT ||
+                            settingsPrefs!!.getInt(KEY_APPS_LAYOUT, 0) != 0) {
+                            it.left
+                        } else 0
+
+                    binding.root.updatePadding(leftInsets, 0, it.right, 0)
+                }
+            }
+
+            WindowInsetsCompat.CONSUMED
         }
     }
 


### PR DESCRIPTION
#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature request (user facing)
- [ ] Codebase improvement (dev facing)

#### Description of the changes in your PR
- Adjusts AppDrawer layout to account for navigation bar overlapping with views in landscape mode.

Didn't update the left/right padding of top most layout in `LauncherActivity.kt>topPadding()` because of some kind of ViewPager preloading artifact(?) issue(See Attachment), instead update the padding AppDrawer's layout where it's needed.

https://github.com/iamrasel/lunar-launcher/assets/125657944/27061aa0-eb8f-4a79-8b31-f58c479d2813



#### Fixes the following issue(s)
- Issue #122
